### PR TITLE
fix: disable set font warning

### DIFF
--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -4842,7 +4842,7 @@ function jsPDF(options) {
       fontStyle = combineFontStyleAndFontWeight(fontStyle, fontWeight);
     }
     activeFontKey = getFont(fontName, fontStyle, {
-      disableWarning: false
+      disableWarning: true
     });
     return this;
   };

--- a/src/jspdf.js
+++ b/src/jspdf.js
@@ -2813,7 +2813,7 @@ function jsPDF(options) {
   var getFont = function(fontName, fontStyle, options) {
     var key = undefined,
       fontNameLowerCase;
-    options = options || {};
+    options = options || {disableWarning: true};
 
     fontName =
       fontName !== undefined ? fontName : fonts[activeFontKey].fontName;


### PR DESCRIPTION
### **User description**
Thanks for contributing to jsPDF! Please follow our
[Contribution Guidelines](https://github.com/MrRio/jsPDF/blob/master/CONTRIBUTING.md#pull-requests)
when creating a pull request.


___

### **PR Type**
Bug fix


___

### **Description**
- Disabled font warnings by setting `disableWarning` to `true` in the `getFont` function.
- Disabled font warnings by setting `disableWarning` to `true` in the `setFont` function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jspdf.js</strong><dd><code>Disable font warnings in `getFont` and `setFont` functions</code></dd></summary>
<hr>

src/jspdf.js

<li>Set <code>disableWarning</code> to <code>true</code> in <code>getFont</code> function.<br> <li> Set <code>disableWarning</code> to <code>true</code> in <code>setFont</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/visualbis/jsPDF/pull/16/files#diff-20cfe6552cd3b0db6b2e763ee8796f230b5f9d480ef0f22beac188cb543b35e8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

